### PR TITLE
Add date range support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
 
     <label>
   From:
-  <input type="month" id="from-month" value="2025-01" />
+  <input type="date" id="from-date" />
 </label>
 <label>
   To:
-  <input type="month" id="to-month" value="2025-07" />
+  <input type="date" id="to-date" />
 </label>
 <button id="confirm-range">Confirm</button>
 

--- a/stats.js
+++ b/stats.js
@@ -123,7 +123,9 @@ const computeMovingAverage = (data, window = 7) =>
 
 const toHighcharts = (arr) => arr.map(([d, v]) => [Date.parse(d), v]);
 
-const fetchSplitStats = async (fromMonth, toMonth) => {
+const fetchSplitStats = async (fromDate, toDate) => {
+  const fromMonth = fromDate.slice(0, 7);
+  const toMonth = toDate.slice(0, 7);
   const jsdelivrRanges = getOptimizedJsDelivrRanges(fromMonth, toMonth);
   console.log(jsdelivrRanges);
   const seenJsDelivr = new Set();
@@ -158,16 +160,19 @@ const fetchSplitStats = async (fromMonth, toMonth) => {
     }
   });
 
-  return { jsdelivr, npm, versions };
+  const filteredJsDelivr = jsdelivr.filter(([d]) => d >= fromDate && d <= toDate);
+  const filteredNpm = npm.filter(([d]) => d >= fromDate && d <= toDate);
+
+  return { jsdelivr: filteredJsDelivr, npm: filteredNpm, versions };
 };
 
-const renderChart = async (fromMonth, toMonth) => {
+const renderChart = async (fromDate, toDate) => {
   const button = document.getElementById("confirm-range");
   const lastUpdated = document.getElementById("last-updated");
   button.disabled = true;
   lastUpdated.textContent = "Loading...";
 
-  const { jsdelivr, npm, versions } = await fetchSplitStats(fromMonth, toMonth);
+  const { jsdelivr, npm, versions } = await fetchSplitStats(fromDate, toDate);
 
   const plotlines = Object.entries(versions).map(([ver, time]) => ({
     value: Date.parse(time),
@@ -232,24 +237,24 @@ const renderChart = async (fromMonth, toMonth) => {
 };
 
 document.getElementById("confirm-range").addEventListener("click", () => {
-  const from = document.getElementById("from-month").value;
-  const to = document.getElementById("to-month").value;
+  const from = document.getElementById("from-date").value;
+  const to = document.getElementById("to-date").value;
 
   if (from && to && from <= to) {
     renderChart(from, to);
   } else {
-    alert("Please select a valid month range.");
+    alert("Please select a valid date range.");
   }
 });
 
-// Set default to last 6 full months
+// Set default to last 6 months
 const today = new Date();
 const thisMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
 const fromDate = new Date(thisMonth);
 fromDate.setUTCMonth(fromDate.getUTCMonth() - 5);
-const defaultFrom = formatMonth(fromDate);
-const defaultTo = formatMonth(thisMonth);
+const defaultFrom = isoDate(fromDate);
+const defaultTo = isoDate(today);
 
-document.getElementById("from-month").value = defaultFrom;
-document.getElementById("to-month").value = defaultTo;
+document.getElementById("from-date").value = defaultFrom;
+document.getElementById("to-date").value = defaultTo;
 renderChart(defaultFrom, defaultTo);

--- a/stats.js
+++ b/stats.js
@@ -247,14 +247,29 @@ document.getElementById("confirm-range").addEventListener("click", () => {
   }
 });
 
-// Set default to last 6 months
-const today = new Date();
-const thisMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
-const fromDate = new Date(thisMonth);
-fromDate.setUTCMonth(fromDate.getUTCMonth() - 5);
-const defaultFrom = isoDate(fromDate);
-const defaultTo = isoDate(today);
+// Initialize default range and input limits
+(async () => {
+  const versions = await getNpmPublishDates();
+  const minDate = Object.values(versions).sort()[0];
+  const today = new Date();
+  const todayIso = isoDate(today);
 
-document.getElementById("from-date").value = defaultFrom;
-document.getElementById("to-date").value = defaultTo;
-renderChart(defaultFrom, defaultTo);
+  const fromInput = document.getElementById("from-date");
+  const toInput = document.getElementById("to-date");
+  fromInput.min = minDate;
+  toInput.min = minDate;
+  fromInput.max = todayIso;
+  toInput.max = todayIso;
+
+  const thisMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+  const fromDate = new Date(thisMonth);
+  fromDate.setUTCMonth(fromDate.getUTCMonth() - 5);
+  if (fromDate < new Date(minDate)) fromDate.setTime(new Date(minDate).getTime());
+  const defaultFrom = isoDate(fromDate);
+  const defaultTo = todayIso;
+
+  fromInput.value = defaultFrom;
+  toInput.value = defaultTo;
+
+  renderChart(defaultFrom, defaultTo);
+})();


### PR DESCRIPTION
## Summary
- switch inputs from `type=month` to `type=date`
- filter jsDelivr and npm data using the exact date range
- default to last six months ending today

## Testing
- `node --check stats.js`

------
https://chatgpt.com/codex/tasks/task_b_688633658230832bbac2fb10f595fe12